### PR TITLE
- Replace deprecated 'hiera_hash' to 'lookup'.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -33,7 +33,7 @@ class cfssl (
   String                $service_user     = $cfssl::params::service_user,
   Boolean               $firewall_manage  = $cfssl::params::firewall_manage,
   Array[String]         $allowed_networks = $cfssl::params::allowed_networks,
-  Hash                  $requests         = hiera_hash('cfssl::requests', {}),
+  Hash                  $requests         = lookup('cfssl::requests', Hash, 'hash', {}),
 ) inherits cfssl::params {
 
   anchor { "${module_name}::begin": }

--- a/metadata.json
+++ b/metadata.json
@@ -57,7 +57,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
+      "version_requirement": ">= 4.7.0 < 5.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
- Update minimum puppet version required is set to 4.7.0.